### PR TITLE
modifi simlator camera param

### DIFF
--- a/burger_war/models/burgerbot.gazebo.xacro
+++ b/burger_war/models/burgerbot.gazebo.xacro
@@ -135,10 +135,11 @@
         <update_rate>10.0</update_rate>
         <camera name="camera">
           <pose>0 0 0 0 ${radians(-90)} ${radians(90)}</pose>
-          <horizontal_fov>1.3962634</horizontal_fov>
+          <!-- horizontal_fov = 49.5 deg --> 
+          <horizontal_fov>0.86392</horizontal_fov>
           <image>
-            <width>800</width>
-            <height>600</height>
+            <width>640</width>
+            <height>480</height>
             <format>R8G8B8</format>
           </image>
           <clip>


### PR DESCRIPTION
カメラパラメータを実機に合わせて変更

解像度を 800x600 から 640x480
水平画角を  80度から49.5度

に変更
