### PR TITLE
バグ修正 マーカーの再度取り返しができない

### DIFF
--- a/burger_war/scripts/sendIdToJudge.py
+++ b/burger_war/scripts/sendIdToJudge.py
@@ -75,8 +75,8 @@ class TargetId(object):
         for marker in markers:
             target_id = str(marker.id)
             target_id = self.lengthTo4(target_id)
-            if target_id in self.historys:
-                return
+            # if target_id in self.historys:
+            #     return
             try:
                 resp_raw = self.sendToJudge(target_id)
             except:
@@ -85,8 +85,8 @@ class TargetId(object):
                 resp = json.loads(resp_raw.text)
                 print("Send " + target_id + " To " + self.judge_url)
                 print(resp)
-                if resp["error"] == "no error" or resp["error"] == "ERR not mutch id":
-                    self.historys.append(target_id)
+                # if resp["error"] == "no error" or resp["error"] == "ERR not mutch id":
+                #     self.historys.append(target_id)
 
 
 class WarStatePublisher(object):


### PR DESCRIPTION
ルールでは
フィールドマーカーは最後に読み取ったチームのポイントになり何度でも取り返せる．
となっていたが，
読み取ったマーカーIDを審判サーバーに送信するノード `send_id_to_judge` にバグがあり，
一度読み取ったマーカーを再度送信することができなくなっていた．（これはマーカーを取り返せない以前のルールのための機能が修正されず残っていたため）
一度読み取ったマーカーを記憶する機能を削除し何度でもマーカーを読み取り送信できるように修正した．